### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ php:
     - 5.6
     - 7.0
     - 7.1
+    - 7.2
     - hhvm
 
 matrix:
@@ -21,7 +22,7 @@ before_script:
 
 script:
     - vendor/bin/phpcs --standard=psr2 ./src
-    - vendor/bin/phpunit --coverage-text --bootstrap vendor/autoload.php --coverage-clover=coverage.xml
+    - vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml
 
 after_success:
     - if [[ $TRAVIS_PHP_VERSION != "hhvm" ]]; then bash <(curl -s https://codecov.io/bash); fi

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
     "require": {
         "php" : "^5.5 || ^7.0"
     },
+    "suggest": {
+        "ext-gmp": "It will speed up the string encoding."
+    },
     "autoload": {
         "psr-4": {
             "Tuupola\\": "src"
@@ -29,7 +32,7 @@
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^2.5",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^4.8 || ^5.5 || ^6.5",
         "paragonie/random_compat": "^2.0",
         "phpbench/phpbench": "^0.13.0",
         "overtrue/phplint": "^0.2.4"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" bootstrap="tests/bootstrap.php">
+<phpunit colors="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" bootstrap="vendor/autoload.php">
     <testsuites>
         <testsuite name="all">
             <directory suffix="Test.php">tests/</directory>
         </testsuite>
     </testsuites>
     <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
         <blacklist>
             <directory suffix=".php">vendor/</directory>
         </blacklist>

--- a/tests/Base58Test.php
+++ b/tests/Base58Test.php
@@ -17,8 +17,9 @@ namespace Tuupola\Base58;
 
 use Tuupola\Base58;
 use Tuupola\Base58Proxy;
+use PHPUnit\Framework\TestCase;
 
-class Base58Test extends \PHPUnit_Framework_TestCase
+class Base58Test extends TestCase
 {
 
     public function testShouldBeTrue()

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,3 +1,0 @@
-<?php
-
-require dirname(__FILE__) . "/../vendor/autoload.php";


### PR DESCRIPTION
# Changed log
- add ```php-7.2``` test.
- remove ```bootstrap.php``` and use ```vendor/autoload.php``` directly.
- use the class-based PHPUnit namespace.
- set the different PHPUnit versions are for the different PHP versions.