### PR TITLE
Make sure empty string returns an empty string (fixes #20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ## [2.2.0](https://github.com/tuupola/base58/compare/2.1.0...2.x) - Unreleased
 
+### Changed
+
 - PHP 7.2 is not the minimum requirement ([#18](https://github.com/tuupola/base58/pull/18))
+
+### Fixed
+
+- PHP versions before 8.2 were returning wrong value when encoding an empty string ([#20](https://github.com/tuupola/base58/issues/20), [#21](https://github.com/tuupola/base58/pull/21))
 
 ## [2.1.0](https://github.com/tuupola/base58/compare/2.0.1...2.1.0) - 2020-09-09
 

--- a/src/Base58/BaseEncoder.php
+++ b/src/Base58/BaseEncoder.php
@@ -59,16 +59,16 @@ abstract class BaseEncoder
      */
     public function encode(string $data): string
     {
-        if ("" === $data) {
-            return "";
-        }
-
         if (true === $this->options["check"]) {
             $data = chr($this->options["version"]) . $data;
             $hash = hash("sha256", $data, true);
             $hash = hash("sha256", $hash, true);
             $checksum = substr($hash, 0, 4);
             $data .= $checksum;
+        }
+
+        if ("" === $data) {
+            return "";
         }
 
         $data = str_split($data);

--- a/src/Base58/BaseEncoder.php
+++ b/src/Base58/BaseEncoder.php
@@ -59,6 +59,10 @@ abstract class BaseEncoder
      */
     public function encode(string $data): string
     {
+        if ("" === $data) {
+            return "";
+        }
+
         if (true === $this->options["check"]) {
             $data = chr($this->options["version"]) . $data;
             $hash = hash("sha256", $data, true);
@@ -96,6 +100,10 @@ abstract class BaseEncoder
     public function decode(string $data): string
     {
         $this->validateInput($data);
+
+        if ("" === $data) {
+            return "";
+        }
 
         $data = str_split($data);
         $data = array_map(function ($character) {


### PR DESCRIPTION
In PHP 8.2 and later, calling str_split("") returns an empty array [].
PHP 8.1 and earlir had a bug and it returns an array containing a single 
empty string [""].